### PR TITLE
Add binary_reduction and array_equal to wrapper

### DIFF
--- a/src/ndarray.cpp
+++ b/src/ndarray.cpp
@@ -233,6 +233,15 @@ void nda_binary_op(CN_NDArray* out, CuPyNumericBinaryOpCode op_code,
   out->obj.binary_op(op_code, rhs1->obj, rhs2->obj);
 }
 
+void nda_binary_reduction(CN_NDArray* out, CuPyNumericBinaryOpCode op_code,
+                   const CN_NDArray* rhs1, const CN_NDArray* rhs2) {
+  out->obj.binary_reduction(op_code, rhs1->obj, rhs2->obj);
+}
+
+CN_NDArray* nda_array_equal(const CN_NDArray* rhs1, const CN_NDArray* rhs2){
+  return new CN_NDArray{cupynumeric::array_equal(rhs1->obj, rhs2->obj)};
+}
+
 void nda_unary_op(CN_NDArray* out, CuPyNumericUnaryOpCode op_code,
                   CN_NDArray* input) {
   out->obj.unary_op(op_code, input->obj);


### PR DESCRIPTION
@krasow please check I used the c-api correctly.


Here is `array_equal` source: https://github.com/nv-legate/cupynumeric/blob/8b4c80c7ffa8dbb8a2cdce7e53324c77316521b0/src/cupynumeric/operators.cc#L345C1-L355C2

Here is the `binary_reduction` source: https://github.com/nv-legate/cupynumeric/blob/8b4c80c7ffa8dbb8a2cdce7e53324c77316521b0/src/cupynumeric/ndarray.cc#L491C15-L491C31